### PR TITLE
Replace bash download via runCmd by simple command. Fix a few typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RET makes the process of carrying out automated ROCm installation incredibly sim
 
 * Install Linux OS
 * Run ret
-* Run your Tensorflow benchmark OR Train your own model with tensorflow
+* Run your TensorFlow benchmark OR Train your own model with TensorFlow
 
 ## Hardware Support and supported GPU
 please refer to ROCm main repository
@@ -16,13 +16,13 @@ at [ROCmInstall](https://rocm.github.io/ROCmInstall.html).
   - Ubuntu: 
       - 16.04
       - 18.04
-  - CentOS 7.6   (Tensorflow run on Docker)
+  - CentOS 7.6   (TensorFlow run on Docker)
   
 ## Prerequisites
 *Note*: it is required to start with a clean system
 
 Formatting a hard drive along with the install of a new OS is the best option
-after the instllation you will need git to download the RET source
+after the installation you will need git to download the RET source
 ```
   sudo apt -y install git
   git clone https://github.com/rocmsys/RET.git
@@ -43,12 +43,12 @@ Command:
 
    Packages:
               [rocm]                             : ROCm-dkms packages
-              [tensorflow]                       : Tensorflow framework
+              [tensorflow]                       : TensorFlow framework
 
    Model:
               [vgg16]                            : vgg16 model}
               [alexnet]                          : alexnet model
-              [resnet50]                         : resnet50 model. Default Model
+              [resnet50]                         : ResNet-50 model. Default Model
    Container:
               [docker]                           : Build Docker Container
               [singularity]                      : Build Singularity Container
@@ -71,13 +71,12 @@ Options:
    cd RET
    sudo ./ret install rocm         # install ROCm stack
    sudo reboot
-   sudo ./ret install tensorflow   # install Tensorflow
+   sudo ./ret install tensorflow   # install TensorFlow
 ```
-
-### Tensorflow's tf_cnn_benchmarks
+### TensorFlow's tf_cnn_benchmarks
 Details on the tf_cnn_benchmarks can be found at this [Link](https://github.com/tensorflow/benchmarks/blob/master/scripts/tf_cnn_benchmarks/README.md).  
 
-Here are the basic instructions to run resnet50 benchmark:
+Here are the basic instructions to run ResNet-50 benchmark:
 ```
 sudo ./ret benchmark tensorflow resnet50
 ```

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -43,13 +43,8 @@ os_support:
     release:
       - 7.5
       - 7.6
-      - 7.7
     kernel:
       - 7.6:
-        - version: 3.10
-        - default: 3.10
-    kernel:
-      - 7.7:
         - version: 3.10
         - default: 3.10
 

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -48,6 +48,10 @@ os_support:
       - 7.6:
         - version: 3.10
         - default: 3.10
+    kernel:
+      - 7.7:
+        - version: 3.10
+        - default: 3.10
 
 # Package dependencies
 dependencies:

--- a/src/cmd
+++ b/src/cmd
@@ -360,13 +360,13 @@ function runPreInstallation {
                 WHL_URL+=$__pytorch_pkg_name_runPreInstallation
                 # Download source file
                 startLoadBar "Download Pytorch whl package"
-                __cmd_array_runPreInstallation=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTRORY $WHL_URL'")
+                __cmd_array_runPreInstallation=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTORY $WHL_URL'")
                 runCmd __cmd_array_runPreInstallation "ERR" "1" "Download Pytorch whl package" "0"
                 stopLoadBar
 
                 # Exclude torch pkg and insert the new pkg name
                 removeFromArray "torch" __pkg_name_arr_runPreInstallation __pkg_vers_arr_runPreInstallation
-                eval __pkg_name_arr_runPreInstallation="(${__pkg_name_arr_runPreInstallation[@]} $TEMP_DIRECTRORY/$__pytorch_pkg_name_runPreInstallation:${PYPI})"
+                eval __pkg_name_arr_runPreInstallation="(${__pkg_name_arr_runPreInstallation[@]} $TEMP_DIRECTORY/$__pytorch_pkg_name_runPreInstallation:${PYPI})"
             fi
         ;;
 

--- a/src/cmd_utils
+++ b/src/cmd_utils
@@ -138,8 +138,8 @@ function tfBenchmark {
     local __cmd_ret_tfBenchmark
     local __ret_value_tfBenchmark=0
 
-    if [ ! -d "$WORK_DIRECTRORY/tf" ]; then 
-        __cmd_array_tfBenchmark=("su -p $SUDO_USER -c 'git clone -b $TF_BNCH_VER $TF_BENCHMARKS_URL $WORK_DIRECTRORY/tf/'"); runCmd __cmd_array_tfBenchmark "WARN"
+    if [ ! -d "$WORK_DIRECTORY/tf" ]; then 
+        __cmd_array_tfBenchmark=("su -p $SUDO_USER -c 'git clone -b $TF_BNCH_VER $TF_BENCHMARKS_URL $WORK_DIRECTORY/tf/'"); runCmd __cmd_array_tfBenchmark "WARN"
     fi
 
     # Run the training benchmark (e.g. ResNet-50)
@@ -148,7 +148,7 @@ function tfBenchmark {
     for model in "${__models_tfBenchmark[@]}"; do
         TF_MODEL=$model
         startLoadBar "Run ${TF_MODEL} benchmark"; printf '\n'
-        su -p $SUDO_USER -c "$__cmd_python_tfBenchmark $WORK_DIRECTRORY/tf/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model=$TF_MODEL --num_gpus=$NUM_GPUS --batch_size=$BATCH_SIZE --use_fp16=True"
+        su -p $SUDO_USER -c "$__cmd_python_tfBenchmark $WORK_DIRECTORY/tf/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model=$TF_MODEL --num_gpus=$NUM_GPUS --batch_size=$BATCH_SIZE --use_fp16=True"
         __cmd_ret_tfBenchmark="$?"
         [ "$__cmd_ret_tfBenchmark" -eq 0 ] && stopLoadBar "${TF_MODEL} benchmark Done" || { stopLoadBar "${TF_MODEL} benchmark Failed" "ERR"; __ret_value_tfBenchmark=1; }
     done
@@ -163,16 +163,16 @@ function namdBenchmark {
     local __cmd_python_namdBenchmark
     local __ret_value_namdBenchmark=0
     
-    if [ ! -d "$WORK_DIRECTRORY/namd" ]; then
-        __cmd_array_namdBenchmark=("su -p $SUDO_USER -c 'git clone $__url_namdBenchmark $WORK_DIRECTRORY/namd/'"); runCmd __cmd_array_namdBenchmark "WARN"
-        __cmd_array_namdBenchmark=("cd $WORK_DIRECTRORY/namd/ && dos2unix ns_per_day.py"); runCmd __cmd_array_namdBenchmark "ERR"
+    if [ ! -d "$WORK_DIRECTORY/namd" ]; then
+        __cmd_array_namdBenchmark=("su -p $SUDO_USER -c 'git clone $__url_namdBenchmark $WORK_DIRECTORY/namd/'"); runCmd __cmd_array_namdBenchmark "WARN"
+        __cmd_array_namdBenchmark=("cd $WORK_DIRECTORY/namd/ && dos2unix ns_per_day.py"); runCmd __cmd_array_namdBenchmark "ERR"
     fi
 
     # Run the benchmark
     startLoadBar "Run APOA1 STMV benchmark on 16 cores"; printf '\n'
 
     [ "$PYVER" = "py2" ] && __cmd_python_namdBenchmark="python" || __cmd_python_namdBenchmark="python3"
-    __cmd_array_namdBenchmark=("cd $WORK_DIRECTRORY/namd/ && export PATH=$PATH:$WORK_DIRECTRORY/namd"); runCmd __cmd_array_namdBenchmark "ERR"
+    __cmd_array_namdBenchmark=("cd $WORK_DIRECTORY/namd/ && export PATH=$PATH:$WORK_DIRECTORY/namd"); runCmd __cmd_array_namdBenchmark "ERR"
 
     __cmd_array_namdBenchmark=("$__cmd_python_namdBenchmark run_benchmarks.py -b apoa1 stmv -c 16-16 -d 0"); runCmd __cmd_array_namdBenchmark "ERR"
     runCmd __cmd_array_namdBenchmark "ERR" 0 && stopLoadBar "APOA1 STMV benchmark Done" || { stopLoadBar "APOA1 STMV benchmark Failed" "ERR"; __ret_value_namdBenchmark=1; }
@@ -297,7 +297,7 @@ function installSingularity {
 
     # Download Go package
     startLoadBar "Download Go"
-    __cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTRORY $__url_go'")
+    __cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTORY $__url_go'")
     runCmd __cmd_array_installSingularity "ERR" "1" "Download Go" "0"
     stopLoadBar
 
@@ -305,7 +305,7 @@ function installSingularity {
     # Install the Go ###################################################################################
     startLoadBar "Install Go"
 
-    __cmd_array_installSingularity=("tar -xzvf $TEMP_DIRECTRORY/go${__version_go}.linux-amd64.tar.gz -C /usr/local")
+    __cmd_array_installSingularity=("tar -xzvf $TEMP_DIRECTORY/go${__version_go}.linux-amd64.tar.gz -C /usr/local")
     runCmd __cmd_array_installSingularity "ERR"
 
     export GOPATH=${HOME}/go
@@ -316,17 +316,17 @@ function installSingularity {
 
     # Download and extract the singularity package ####################################################
     startLoadBar "Download Singularity"
-    __cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTRORY $__url_installSingularity'")
+    __cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTORY $__url_installSingularity'")
     runCmd __cmd_array_installSingularity "ERR" "1" "Download Singularity" "0"
     stopLoadBar
 
     # Install the singularity
     startLoadBar "Install Singularity"
 
-    __cmd_array_installSingularity=("su -p $SUDO_USER -c \"tar -xzf $TEMP_DIRECTRORY/singularity-$__version_installSingularity.tar.gz -C $TEMP_DIRECTRORY\"")
+    __cmd_array_installSingularity=("su -p $SUDO_USER -c \"tar -xzf $TEMP_DIRECTORY/singularity-$__version_installSingularity.tar.gz -C $TEMP_DIRECTORY\"")
     runCmd __cmd_array_installSingularity "ERR"
 
-    cd "$TEMP_DIRECTRORY/singularity"
+    cd "$TEMP_DIRECTORY/singularity"
 
     __cmd_array_installSingularity=("su -p $SUDO_USER -c \"./mconfig\"")
     runCmd __cmd_array_installSingularity "ERR"
@@ -361,7 +361,7 @@ function installNAMD {
     local __url_rocCUB_installNAMD="https://github.com/ROCmSoftwarePlatform/hipCUB.git"
 
     local __nProc_installNAMD=`grep -c ^processor /proc/cpuinfo`
-    local __inst_root_installNAMD="$TEMP_DIRECTRORY/NAMD"
+    local __inst_root_installNAMD="$TEMP_DIRECTORY/NAMD"
 
     # Confirmation message
     logPrint "STEP" "Build NAMD"

--- a/src/definitions
+++ b/src/definitions
@@ -27,14 +27,14 @@ REQ_BASH_VERSION=4.3
 
 
 # DIRECTORY Paths
-TEMP_DIRECTRORY=$(su -p $SUDO_USER -c "mktemp -d")
-WORK_DIRECTRORY="$PWD/benchmarks"
-LOG_DIRECTRORY="$PWD/log"
+TEMP_DIRECTORY=$(su -p $SUDO_USER -c "mktemp -d")
+WORK_DIRECTORY="$PWD/benchmarks"
+LOG_DIRECTORY="$PWD/log"
 
 # File Paths
 REQ_FILE="requirements/req.yml"
 DEF_FILE="src/definitions"
-LOG_FILE="${LOG_DIRECTRORY}/ret.log"
+LOG_FILE="${LOG_DIRECTORY}/ret.log"
 BASH_FILENAME="bash-4.4.18"
 Ubuntu_ROCM_REPO="/etc/apt/sources.list.d/rocm.list"
 CentOS_ROCM_REPO="/etc/yum.repos.d/rocm.repo"

--- a/src/functions
+++ b/src/functions
@@ -918,8 +918,8 @@ function checkBashVersion {
     confirmYn "Update to $BASH_FILENAME? [Y/n] " || logPrint "ERR" "Update Bash: The Current Bash Version is Not Supported!" "$__bash_ver" "${FAIL}"
 
     # Download and extract the bash package
-    downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
     startLoadBar "Download $BASH_FILENAME"
+    downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
     stopLoadBar
 
     tar zxvf "$TEMP_DIRECTORY/$BASH_FILENAME.$__file_extension" -C "$TEMP_DIRECTORY" >/dev/null 2>&1

--- a/src/functions
+++ b/src/functions
@@ -824,7 +824,7 @@ function initLog {
     local __msg_initLog="${1:-START SCRIPT}"
 
     # Creat log directory
-    su -p $SUDO_USER -c "mkdir '${LOG_DIRECTRORY}'" >/dev/null 2>&1
+    su -p $SUDO_USER -c "mkdir '${LOG_DIRECTORY}'" >/dev/null 2>&1
 
     # re-create the log file
     su -p $SUDO_USER -c "rm -f $LOG_FILE" >/dev/null 2>&1
@@ -838,7 +838,7 @@ function initLog {
 
     # Add the first msg after header
     toLog "INFO" "${__msg_initLog} [USER: $SUDO_USER]"
-    toLog "INFO" "${TEMP_DIRECTRORY} [tmp Path]"
+    toLog "INFO" "${TEMP_DIRECTORY} [tmp Path]"
 }
 
 # Insert log message to the log file
@@ -890,20 +890,21 @@ function checkBashVersion {
     confirmYn "Update to $BASH_FILENAME? [Y/n] " || logPrint "ERR" "Update Bash: The Current Bash Version is Not Supported!" "$__bash_ver" "${FAIL}"
 
     # Download and extract the bash package
-    #downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTRORY" "ERR" "Download $BASH_FILENAME"
+    #downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
     startLoadBar "Download $BASH_FILENAME"
-    __cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTRORY $BASH_URL$BASH_FILENAME.$__file_extension'")
-    runCmd __cmd_array_installSingularity "ERR" "1" "Download $BASH_FILENAME" "0"
+    #__cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTORY $BASH_URL$BASH_FILENAME.$__file_extension'")  # 
+    #runCmd __cmd_array_installSingularity "ERR" "1" "Download $BASH_FILENAME" "0"                                                               # does not work with bash version < 4.3
+    wget --progress=dot -P $TEMP_DIRECTORY $BASH_URL$BASH_FILENAME.$__file_extension
     stopLoadBar
 
-    tar zxvf "$TEMP_DIRECTRORY/$BASH_FILENAME.$__file_extension" -C "$TEMP_DIRECTRORY" >/dev/null 2>&1
+    tar zxvf "$TEMP_DIRECTORY/$BASH_FILENAME.$__file_extension" -C "$TEMP_DIRECTORY" >/dev/null 2>&1
     __cmd_ret_checkBashVersion="$?"
-    checkReturn "$__cmd_ret_checkBashVersion" "tar zxvf $TEMP_DIRECTRORY/$BASH_FILENAME.$__file_extension -C $TEMP_DIRECTRORY" "ERR"
+    checkReturn "$__cmd_ret_checkBashVersion" "tar zxvf $TEMP_DIRECTORY/$BASH_FILENAME.$__file_extension -C $TEMP_DIRECTORY" "ERR"
 
     # Install the new bash version
     startLoadBar "Install $BASH_FILENAME"
 
-    cd "$TEMP_DIRECTRORY/$BASH_FILENAME"
+    cd "$TEMP_DIRECTORY/$BASH_FILENAME"
     ./configure >/dev/null 2>&1
     __cmd_ret_checkBashVersion="$?"
     checkReturn "$__cmd_ret_checkBashVersion" "./configure" "ERR"
@@ -923,7 +924,7 @@ function checkBashVersion {
     # Back to the RET folder
     cd "$__retPath_checkBashVersion"
 
-    [ $__cmd_ret_checkBashVersion -ne 0 ] && stopLoadBar "There was a problem installing $BASH_FILENAME!" "ERR" "make -C $TEMP_DIRECTRORY/$BASH_FILENAME" \
+    [ $__cmd_ret_checkBashVersion -ne 0 ] && stopLoadBar "There was a problem installing $BASH_FILENAME!" "ERR" "make -C $TEMP_DIRECTORY/$BASH_FILENAME" \
                                       || stopLoadBar "Update Completed Successfully."
 
     # Feedback info: The location of the old version, the current version
@@ -950,7 +951,7 @@ function runCmd {
     local __cmd_ret_runCmd
     local __pid_runCmd
 
-    [ "${#__cmd_runCmd[@]}" -eq 0 ] && logPrint "ERR" "Command Can Not Be Empty!" "runCmd"
+    [ "${#__cmd_runCmd[@]}" -eq 0 ] && logPrint "ERR" "Command Cannot Be Empty!" "runCmd"
     if [ "${__cmd_runCmd}" != "$RET_IGNORE_CMD" ]; then
         toLog "CMD" "${__cmd_runCmd[@]} [runCmd]"
 

--- a/src/functions
+++ b/src/functions
@@ -854,32 +854,42 @@ function toLog {
     fi
 }
 
-# Download a file into a directory.
-# Input $1: The URL of the file
-# Input $2: The download folder
+# Download file from URL
+# Input $1: URL
+# Input $2: Output Path
 # Input $3: Error type [ERR (stop the execution), WARN (only show the warning an keep running)]
-# Input $4: Message (Optional)
-# Input $5: Check process output (Optional)
-# Sample usage: 
-# downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
+# Input $4: Message text
 function downloadFile {
-    local __url_downloadFile="$1"
-    local __folder_downloadFile="$2"
-    local __err_type_downloadFile="$3"
-    local __msg_downloadFile="$4"
-    local __update_msg_downloadFile="${5:-1}"
+    local __err_type_downloadFile=$3
+    local __cmd_ret_downloadFile
+    local __msg_txt_downloadFile=${4:-"Download file"}
 
-    [ "$__url_downloadFile" == "" ] && logPrint "ERR" "URL Cannot Be Empty!" "downloadFile"
-    [ ! -d "$__folder_downloadFile" ] && logPrint "ERR" "Download Folder Must Exist! It is: ${__folder_downloadFile}" "downloadFile"
-   
-    __cmd_downloadFile="su -p $SUDO_USER -c \"wget --progress=dot -P $__folder_downloadFile $__url_downloadFile\""
- 
-    toLog "CMD" "${__cmd_downloadFile} [downloadFile]"
-    eval "${__cmd_downloadFile}" &> >(treatStdout "$__update_msg_downloadFile" "$__msg_downloadFile")
+    # Read terminal output and pass it to loadBar
+    function updatePercentage {
+        local __download_per
+        local __LoadBar_Pos=0
+        local __succ_updatePercentage=1
+        local __previous_value_updatePercentage="${__download_per}"
+
+        while read __download_per
+        do
+            if [ "${__download_per}" != "${__previous_value_updatePercentage}" ]; then
+                ((__LoadBar_Pos++)); __LoadBar_Pos=$((__LoadBar_Pos % ${#LOADBAR}))
+                startLoadBar "${__msg_txt_downloadFile}: ${__download_per}" ${__LoadBar_Pos}
+                __previous_value_updatePercentage="${__download_per}"
+                __succ_updatePercentage=0
+            fi
+        done
+        [ $__succ_updatePercentage -eq 0 ] && stopLoadBar "Download Finished!" || stopLoadBar
+        return $__succ_updatePercentage;
+    }
+
+    # Download file and get the current download state
+    su -p $SUDO_USER -c "wget --progress=dot -P '$2' '$1' 2>&1 | grep --line-buffered '[[:space:]][[:digit:]][[:digit:]]*%' | sed -u -e 's|.* \([0-9]\+[0-9]*\%\).*|\1|g'" | updatePercentage
+
+    # Check the return state
     __cmd_ret_downloadFile="$?"
-
-    __pid_downloadFile=$!; wait "$__pid_downloadFile" >/dev/null 2>&1 # Wait for command to finish 
-    checkReturn "$__cmd_ret_downloadFile" "${__cmd_downloadFile}" "$__err_type_downloadFile" # always check return
+    checkReturn "$__cmd_ret_downloadFile" "wget -P $2 $1" "${__err_type_downloadFile}" "There was a problem downloading this package!"
 }
 
 # Check Bash Version and Update it if requiered

--- a/src/functions
+++ b/src/functions
@@ -854,6 +854,34 @@ function toLog {
     fi
 }
 
+# Download a file into a directory.
+# Input $1: The URL of the file
+# Input $2: The download folder
+# Input $3: Error type [ERR (stop the execution), WARN (only show the warning an keep running)]
+# Input $4: Message (Optional)
+# Input $5: Check process output (Optional)
+# Sample usage: 
+# downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
+function downloadFile {
+    local __url_downloadFile="$1"
+    local __folder_downloadFile="$2"
+    local __err_type_downloadFile="$3"
+    local __msg_downloadFile="$4"
+    local __update_msg_downloadFile="${5:-1}"
+
+    [ "$__url_downloadFile" == "" ] && logPrint "ERR" "URL Cannot Be Empty!" "downloadFile"
+    [ ! -d "$__folder_downloadFile" ] && logPrint "ERR" "Download Folder Must Exist! It is: ${__folder_downloadFile}" "downloadFile"
+   
+    __cmd_downloadFile="su -p $SUDO_USER -c \"wget --progress=dot -P $__folder_downloadFile $__url_downloadFile\""
+ 
+    toLog "CMD" "${__cmd_downloadFile} [downloadFile]"
+    eval "${__cmd_downloadFile}" &> >(treatStdout "$__update_msg_downloadFile" "$__msg_downloadFile")
+    __cmd_ret_downloadFile="$?"
+
+    __pid_downloadFile=$!; wait "$__pid_downloadFile" >/dev/null 2>&1 # Wait for command to finish 
+    checkReturn "$__cmd_ret_downloadFile" "${__cmd_downloadFile}" "$__err_type_downloadFile" # always check return
+}
+
 # Check Bash Version and Update it if requiered
 function checkBashVersion {
     local __bash_ver
@@ -890,11 +918,8 @@ function checkBashVersion {
     confirmYn "Update to $BASH_FILENAME? [Y/n] " || logPrint "ERR" "Update Bash: The Current Bash Version is Not Supported!" "$__bash_ver" "${FAIL}"
 
     # Download and extract the bash package
-    #downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
+    downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
     startLoadBar "Download $BASH_FILENAME"
-    #__cmd_array_installSingularity=("su -p $SUDO_USER -c 'wget --progress=dot -P $TEMP_DIRECTORY $BASH_URL$BASH_FILENAME.$__file_extension'")  # 
-    #runCmd __cmd_array_installSingularity "ERR" "1" "Download $BASH_FILENAME" "0"                                                               # does not work with bash version < 4.3
-    wget --progress=dot -P $TEMP_DIRECTORY $BASH_URL$BASH_FILENAME.$__file_extension
     stopLoadBar
 
     tar zxvf "$TEMP_DIRECTORY/$BASH_FILENAME.$__file_extension" -C "$TEMP_DIRECTORY" >/dev/null 2>&1

--- a/src/functions
+++ b/src/functions
@@ -855,6 +855,8 @@ function toLog {
 }
 
 # Download file from URL
+# NOTE: Can be used with older bash < 4.3. runCmd requires bash >= 4.3 and can thus 
+# not be used to replace this function in all scenarios.
 # Input $1: URL
 # Input $2: Output Path
 # Input $3: Error type [ERR (stop the execution), WARN (only show the warning an keep running)]

--- a/src/functions
+++ b/src/functions
@@ -928,9 +928,7 @@ function checkBashVersion {
     confirmYn "Update to $BASH_FILENAME? [Y/n] " || logPrint "ERR" "Update Bash: The Current Bash Version is Not Supported!" "$__bash_ver" "${FAIL}"
 
     # Download and extract the bash package
-    startLoadBar "Download $BASH_FILENAME"
     downloadFile "$BASH_URL$BASH_FILENAME.$__file_extension" "$TEMP_DIRECTORY" "ERR" "Download $BASH_FILENAME"
-    stopLoadBar
 
     tar zxvf "$TEMP_DIRECTORY/$BASH_FILENAME.$__file_extension" -C "$TEMP_DIRECTORY" >/dev/null 2>&1
     __cmd_ret_checkBashVersion="$?"

--- a/src/update_kernel
+++ b/src/update_kernel
@@ -80,7 +80,7 @@ function updateKernel {
     case "$1" in
         "Ubuntu") [[ ! -z "${__kernel_type_updateKernel##*-}" ]] && __kernel_type_updateKernel=${__kernel_type_updateKernel##*-} \
 		                                                 || __kernel_type_updateKernel=${__kernel_type_updateKernel#*-}
-	          getKernel "$UBUNTU_KERNEL_URL" "${__default_kernel[0]}" "$__sys_arch_updateKernel" "$__kernel_type_updateKernel" "$TEMP_DIRECTRORY" ;;
+	          getKernel "$UBUNTU_KERNEL_URL" "${__default_kernel[0]}" "$__sys_arch_updateKernel" "$__kernel_type_updateKernel" "$TEMP_DIRECTORY" ;;
 
         "RedHat") logPrint "ERR" "Update Kernel: OS Distro Not Supported!" "$1" "${FAIL}" ;;
 	    "CentOS") logPrint "ERR" "Update Kernel: OS Distro Not Supported!" "$1" "${FAIL}" ;;
@@ -90,9 +90,9 @@ function updateKernel {
     # kernel Installation
     logPrint "STEP" "Install the Kernel packages"
     startLoadBar "Install kernel packages"
-    dpkg -i "$TEMP_DIRECTRORY/"linux*.deb >/dev/null 2>&1
+    dpkg -i "$TEMP_DIRECTORY/"linux*.deb >/dev/null 2>&1
     __cmd_ret_updateKernel="$?"
-    [ $__cmd_ret_updateKernel -ne 0 ] && stopLoadBar "There was a problem installing the kernel!" "ERR" "dpkg -i $TEMP_DIRECTRORY/linux*.deb" \
+    [ $__cmd_ret_updateKernel -ne 0 ] && stopLoadBar "There was a problem installing the kernel!" "ERR" "dpkg -i $TEMP_DIRECTORY/linux*.deb" \
                                       || { stopLoadBar "Download Completed Successfully."; update-grub >/dev/null 2>&1; }
 
 


### PR DESCRIPTION
RET uses array references and thus requires bash 4.3+.

The problem with the original bash installation procedure was
that this procedure itself required bash 4.3+ because of the "runCmd" function.
I simply use wget here now.

Minors:

* Fixed typos: *_DIRECTRORY -> *_DIRECTORY
* Added kernel version entry (3.10) for CentOS 7.7 in requirements/req.yml