### PR TITLE
Support ROCm-enabled MPI library and OSU benchmark

### DIFF
--- a/requirements/mpi.yml
+++ b/requirements/mpi.yml
@@ -1,0 +1,25 @@
+# This file contains only dependencies required by Open MPI, UCX, GDRcopy
+---
+- name: git
+  version: latest
+- name: m4
+  version: latest
+- name: autoconf
+  version: latest
+- name: automake
+  version: latest
+- name: libtool
+  version: latest
+- name: flex
+  version: latest
+
+# Define here Ubuntu Packages
+- Ubuntu:
+  - name: python3-dev
+    version: latest
+
+# Define here CentOS Packages
+- CentOS:
+  - name: python36-devel
+    version: latest
+...

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -164,6 +164,9 @@ dependencies:
   - namd:
     - req_file: namd.yml
     
+  - mpi:
+    - req_file: mpi.yml
+
 # Project description
 description: ROCm Machine Learning one-script installer xxxxxxxxxxxx xxxxxxxxxxxxxxxxxx xx xxxxxxxxxxxxxxxx 
 ...

--- a/src/cmd
+++ b/src/cmd
@@ -436,11 +436,10 @@ function runPostInstallation {
         ;;
         mpi)
             startLoadBar "Run ${__pkg_name_runPostInstallation} Post-Installation: Setting PATH and LD_LIBRARY_PATH in /etc/profile.d/mpi.sh "; printf '\n'
-            # Put the ROCm binaries in PATH
-            ROCM_PATH=/opt/rocm
-            __cmd_array_runPostInstallation=("echo 'export PATH=/opt/rocm/RET/ompi/bin:/opt/rocm/RET/ucx/bin:${PATH}' | tee -a /etc/profile.d/mpi.sh")
+            RET_MPI="${PWD}/RET_MPI"
+            __cmd_array_runPostInstallation=("echo 'export PATH=${RET_MPI}/ompi/bin:${RET_MPI}/ucx/bin:${PATH}' | tee -a /etc/profile.d/mpi.sh")
             runCmd __cmd_array_runPostInstallation "ERR"
-            __cmd_array_runPostInstallation=("echo 'export LD_LIBRARY_PATH=/opt/rocm/RET/ompi/lib:/opt/rocm/RET/ucx/lib:/opt/rocm/RET/gdrcopy/lib64:${LD_LIBRARY_PATH}' | tee -a /etc/profile.d/mpi.sh")
+            __cmd_array_runPostInstallation=("echo 'export LD_LIBRARY_PATH=${RET_MPI}/ompi/lib:${RET_MPI}/ucx/lib:${RET_MPI}/gdrcopy/lib64:${LD_LIBRARY_PATH}' | tee -a /etc/profile.d/mpi.sh")
             runCmd __cmd_array_runPostInstallation "ERR"
             __cmd_array_runPostInstallation=("source /etc/profile.d/mpi.sh")
             runCmd __cmd_array_runPostInstallation "ERR"

--- a/src/cmd
+++ b/src/cmd
@@ -29,6 +29,7 @@ function printUsage {
     echo -e "    [pytorch]                          ${FG_LIGHT_BLUE}: Pytorch Framework${END}"
     echo -e ""
     echo -e "${BOLD}HPC Package:${END}"
+    echo -e "    [mpi]                              ${FG_LIGHT_BLUE}: ROCm-enabled MPI library${END}"
     echo -e "    [namd]                             ${FG_LIGHT_BLUE}: NAMD HPC Application${END}"
     echo -e ""
     echo -e "${BOLD}Container:${END}"
@@ -137,7 +138,7 @@ function parseArgs {
             ;;
 
             # Set Packages ########################################################################
-            "rocm" | "tensorflow" | "pytorch" | "namd")
+            "rocm" | "tensorflow" | "pytorch" | "namd" | "mpi" )
                 # Permitted commands: install, remove and update
                 if [[ ! "$__cmd_parseArgs" =~ ^("install"|"update"|"remove"|"benchmark")$ ]]; then logPrint "ERR" "Wrong command! Did you mean: $0 install $__arg_parseArgs"; exit; fi
                 if [[ "$__arg_parseArgs" =~ ^("tensorflow"|"pytorch")$ ]]; then 
@@ -146,6 +147,7 @@ function parseArgs {
                 fi
 
                 [[ "$__arg_parseArgs" = "namd" ]] && { __arg_parseArgs="$__arg_parseArgs:src"; __isROCmRequired_parseArgs=0; }
+                [[ "$__arg_parseArgs" = "mpi" ]] && { __arg_parseArgs="$__arg_parseArgs:src"; __isROCmRequired_parseArgs=0; }
                 __pkgs_parseArgs+=("$__arg_parseArgs");
               shift
             ;;
@@ -252,6 +254,9 @@ function installCmd {
             namd*)
                 __cmd_array_installCmd=("source /etc/profile.d/namd.sh"); runCmd __cmd_array_installCmd "ERR" 0
             ;;
+            mpi*)
+                __cmd_array_installCmd=("source /etc/profile.d/mpi.sh"); runCmd __cmd_array_installCmd "ERR" 0
+            ;;
 	    esac
         # Install Package
         runInstall "$pkg"
@@ -295,6 +300,9 @@ function runInstall {
                 ;;
                 namd)
                     installNAMD;
+                ;;
+                mpi)
+                    installMPI;
                 ;;
             esac
 
@@ -376,7 +384,7 @@ function runPreInstallation {
             local __docker_pkg_runPreInstallation=("docker-*"); removePkg __docker_pkg_runPreInstallation
         ;;
 
-        py2 | py3 | singularity | namd)
+        py2 | py3 | singularity | namd | mpi )
             PRE="DONOTHING"
         ;;
     esac
@@ -426,6 +434,18 @@ function runPostInstallation {
             addPATH "namd" "$PWD/../RET_NAMD"
             stopLoadBar
         ;;
+        mpi)
+            startLoadBar "Run ${__pkg_name_runPostInstallation} Post-Installation: Setting PATH and LD_LIBRARY_PATH in /etc/profile.d/mpi.sh "; printf '\n'
+            # Put the ROCm binaries in PATH
+            ROCM_PATH=/opt/rocm
+            __cmd_array_runPostInstallation=("echo 'export PATH=/opt/rocm/RET/ompi/bin:/opt/rocm/RET/ucx/bin:${PATH}' | tee -a /etc/profile.d/mpi.sh")
+            runCmd __cmd_array_runPostInstallation "ERR"
+            __cmd_array_runPostInstallation=("echo 'export LD_LIBRARY_PATH=/opt/rocm/RET/ompi/lib:/opt/rocm/RET/ucx/lib:/opt/rocm/RET/gdrcopy/lib64:${LD_LIBRARY_PATH}' | tee -a /etc/profile.d/mpi.sh")
+            runCmd __cmd_array_runPostInstallation "ERR"
+            __cmd_array_runPostInstallation=("source /etc/profile.d/mpi.sh")
+            runCmd __cmd_array_runPostInstallation "ERR"
+            stopLoadBar
+        ;;
     esac
 }
 
@@ -473,6 +493,11 @@ function runVerification {
 
         namd)
             namdVerification
+            return "$?";
+        ;;
+        mpi )
+            __cmd_array_runVerification=("source /etc/profile.d/mpi.sh && mpirun --version");
+            mpiVerification
             return "$?";
         ;;
     esac
@@ -577,5 +602,10 @@ function runBenchmark {
             namdBenchmark
             return "$?";
         ;;
+        mpi)
+            mpiBenchmark
+            return "$?";
+        ;;
     esac
 }
+

--- a/src/cmd_utils
+++ b/src/cmd_utils
@@ -193,29 +193,33 @@ function namdBenchmark {
 
 # Run MPI benchmark
 function mpiBenchmark {
-    export OMPI_HOME=/opt/rocm/RET/ompi
+    export RET_MPI=${WORK_DIRECTRORY}/RET_MPI
     #local __url_mpiBenchmark="https://github.com/ROCmSoftwarePlatform/hipOMB.git"
     local __url_mpiBenchmark="https://github.com/yuq/osu-micro-benchmarks-5.3.2.git"
     local __cmd_array_mpiBenchmark=()
-    local __cmd_mpirun_mpiBenchmark="${OMPI_HOME}/bin/mpirun"
+    local __cmd_mpirun_mpiBenchmark="mpirun"
     local __cmd_ret_mpiBenchmark
     local __ret_value_mpiBenchmark=0
 
-    if [ ! -d "/opt/rocm/RET/omb" ]; then
-        startLoadBar "Setting up OSU MPI Benchmark"; printf '\n'
-        __cmd_array_mpiBenchmark=("cd /opt/rocm/RET && git clone $__url_mpiBenchmark omb")
-	runCmd __cmd_array_mpiBenchmark "WARN"
-	__cmd_array_mpiBenchmark=("cd /opt/rocm/RET/omb && autoreconf -ivf && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=/opt/rocm/RET/omb CC=$OMPI_HOME/bin/mpic++ CXX=$OMPI_HOME/bin/mpicxx LDFLAGS='-L$OMPI_HOME/lib -lmpi -L/opt/rocm/lib -lhip_hcc' CPPFLAGS='-std=c++11' && make -j install")
-        runCmd __cmd_array_mpiBenchmark "ERR"
-        stopLoadBar
-    fi
+    startLoadBar "Setting up OSU MPI Benchmark"; printf '\n'
+
+    __cmd_array_mpiBenchmark=("su -p $SUDO_USER -c 'rm -fr $RET_MPI/omb'")
+    runCmd __cmd_array_mpiBenchmark "WARN"
+    __cmd_array_mpiBenchmark=("su -p $SUDO_USER -c 'mkdir -p $RET_MPI/omb'")
+    runCmd __cmd_array_mpiBenchmark "ERR"
+    __cmd_array_mpiBenchmark=("su -p $SUDO_USER -c 'cd $RET_MPI && git clone $__url_mpiBenchmark omb'")
+    runCmd __cmd_array_mpiBenchmark "WARN"
+    __cmd_array_mpiBenchmark=("su -p $SUDO_USER -c \"source /etc/profile.d/mpi.sh && cd $RET_MPI/omb && autoreconf -ivf && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=$RET_MPI/omb CC=mpicc CXX=mpicxx LDFLAGS='-L$RET_MPI/ompi/lib -lmpi -L/opt/rocm/lib -lhip_hcc' CPPFLAGS='-std=c++11' && make -j install\"")
+    runCmd __cmd_array_mpiBenchmark "ERR"
+
+    stopLoadBar
 
     # Run the benchmark
     startLoadBar "Run OSU MPI Benchmark"; printf '\n'
 
-    __cmd_array_mpiBenchmark=("source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr /opt/rocm/RET/omb/mpi/pt2pt/osu_bw -d rocm D D 0 1 ")
+    __cmd_array_mpiBenchmark=("su -p $SUDO_USER -c \"source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr $RET_MPI/omb/mpi/pt2pt/osu_bw -d rocm D D 0 1 \"")
     runCmd __cmd_array_mpiBenchmark "ERR"
-    #__cmd_array_mpiBenchmark=("source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr /opt/rocm/RET/omb/mpi/pt2pt/osu_lat -d rocm D D 0 1 ")
+    #__cmd_array_mpiBenchmark=("source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr $RET_MPI/omb/mpi/pt2pt/osu_lat -d rocm D D 0 1 ")
     #runCmd __cmd_array_mpiBenchmark "ERR"
 
     __cmd_ret_mpiBenchmark="$?"
@@ -477,12 +481,17 @@ function installMPI {
     local __url_GDRCOPY_installMPI="https://github.com/NVIDIA/gdrcopy.git -b v1.3"
     local __url_UCX_installMPI="https://github.com/openucx/ucx.git -b v1.6.x"
 
-    local __inst_root_installMPI="/opt/rocm/RET"
+    local __inst_root_installMPI="${PWD}/RET_MPI"
     local __inst_root_installOpenMPI="$__inst_root_installMPI/ompi"
     local __inst_root_installGDRCOPY="$__inst_root_installMPI/gdrcopy"
     local __inst_root_installGDRCOPY_LIB="$__inst_root_installGDRCOPY/lib64"
     local __inst_root_installGDRCOPY_INCLUDE="$__inst_root_installGDRCOPY/include"
     local __inst_root_installUCX="$__inst_root_installMPI/ucx"
+
+    if [ ! -d "$__inst_root_installMPI" ]; then
+        __cmd_array_installMPI=("su -p $SUDO_USER -c 'mkdir -p $__inst_root_installMPI'")
+        runCmd __cmd_array_installMPI "ERR"
+    fi
 
     # Build GDRCPY ##############################################################################################
     startLoadBar "Build GDRcopy"
@@ -491,12 +500,8 @@ function installMPI {
         __cmd_array_installMPI=("rm -fr $__inst_root_installGDRCOPY")
         runCmd __cmd_array_installMPI "ERR"
     fi
-    __cmd_array_installMPI=("git clone ${__url_GDRCOPY_installMPI} $__inst_root_installGDRCOPY")
-    runCmd __cmd_array_installMPI "ERR"
-    __cmd_array_installMPI=("cd $__inst_root_installGDRCOPY && mkdir -p $__inst_root_installGDRCOPY_LIB $__inst_root_installGDRCOPY_INCLUDE")
-    runCmd __cmd_array_installMPI "ERR"
-    __cmd_array_installMPI=("make PREFIX=$__inst_root_installGDRCOPY lib install && cd $__inst_root_installMPI")
-    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("cd $__inst_root_installGDRCOPY && mkdir -p $__inst_root_installGDRCOPY_LIB $__inst_root_installGDRCOPY_INCLUDE" "make PREFIX=$__inst_root_installGDRCOPY lib install && cd $__inst_root_installMPI")
+    buildFromSource "$__url_GDRCOPY_installMPI" "$__inst_root_installGDRCOPY" __cmd_array_installMPI "gdrcopy" "gdrcopy" "0"
 
     stopLoadBar "Build GDRcopy completed successfully."
 
@@ -507,11 +512,9 @@ function installMPI {
         __cmd_array_installMPI=("rm -fr $__inst_root_installUCX")
         runCmd __cmd_array_installMPI "ERR"
     fi
-    __cmd_array_installMPI=("git clone ${__url_UCX_installMPI} $__inst_root_installUCX")
-    runCmd __cmd_array_installMPI "ERR"
-    __cmd_array_installMPI=("cd $__inst_root_installUCX && ./autogen.sh && mkdir build && cd build && ../contrib/configure-release --prefix=$__inst_root_installUCX --with-rocm=/opt/rocm --with-gdrcopy=$__inst_root_installGDRCOPY --enable-gtest --enable-examples && sudo make -j install && cd $__inst_root_installMPI")
-    #buildFromSource "$__url_UCX_installMPI" "$__inst_root_installUCX" __cmd_array_installMPI "ucx" "ucx" "0"
-    runCmd __cmd_array_installMPI "ERR"
+
+    __cmd_array_installMPI=("cd $__inst_root_installUCX && ./autogen.sh && mkdir build && cd build && ../contrib/configure-release --prefix=$__inst_root_installUCX --with-rocm=/opt/rocm --with-gdrcopy=$__inst_root_installGDRCOPY --enable-gtest --enable-examples" "make -j install && cd $__inst_root_installMPI")
+    buildFromSource "$__url_UCX_installMPI" "$__inst_root_installUCX" __cmd_array_installMPI "ucx" "ucx" "0"
 
     stopLoadBar "Build UCX completed successfully."
 
@@ -522,11 +525,8 @@ function installMPI {
         __cmd_array_installMPI=("rm -fr $__inst_root_installOpenMPI")
         runCmd __cmd_array_installMPI "ERR"
     fi
-    __cmd_array_installMPI=("git clone ${__url_OpenMPI_installMPI} $__inst_root_installOpenMPI")
-    runCmd __cmd_array_installMPI "ERR"
-    __cmd_array_installMPI=("cd $__inst_root_installOpenMPI && ./autogen.pl && mkdir build && cd build && ../configure --prefix=$__inst_root_installOpenMPI --with-ucx=$__inst_root_installUCX --enable-mca-no-build=btl-uct && sudo make -j install && cd $__inst_root_installMPI")
-    #buildFromSource "$__url_OpenMPI_installMPI" "$__inst_root_installOpenMPI" __cmd_array_installMPI "ompi" "ompi" "0"
-    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("cd $__inst_root_installOpenMPI && ./autogen.pl && mkdir build && cd build && ../configure --prefix=$__inst_root_installOpenMPI --with-ucx=$__inst_root_installUCX --enable-mca-no-build=btl-uct" "make -j install && cd $__inst_root_installMPI")
+    buildFromSource "$__url_OpenMPI_installMPI" "$__inst_root_installOpenMPI" __cmd_array_installMPI "ompi" "ompi" "0"
 
     stopLoadBar "Build Open MPI completed successfully."
 

--- a/src/cmd_utils
+++ b/src/cmd_utils
@@ -58,7 +58,7 @@ function addDockerRepo {
     stopLoadBar
 }
 
-# Verify if ROCm installation was successful 
+# Verify if ROCm installation was successful
 function rocmVerification {
     local __cmd_ret_rocmVerification
     local __cmd_rocmVerification="/opt/rocm/bin/rocminfo"
@@ -130,6 +130,17 @@ function namdVerification {
     fi
 }
 
+# Verify if MPI installation was successful
+function mpiVerification {
+    if (confirmYn "Run OSU MPI benchmark? [Y/n] "); then
+        startLoadBar "Run OSU MPI Verification"; printf '\n'
+        runBenchmark "mpi" EMPTY_ARRAY
+        stopLoadBar
+        return "$?"
+    fi
+    return 0;
+}
+
 # Run TensorFlow benchmark
 function tfBenchmark {
     local -n __models_tfBenchmark=$1
@@ -153,7 +164,7 @@ function tfBenchmark {
         [ "$__cmd_ret_tfBenchmark" -eq 0 ] && stopLoadBar "${TF_MODEL} benchmark Done" || { stopLoadBar "${TF_MODEL} benchmark Failed" "ERR"; __ret_value_tfBenchmark=1; }
     done
 
-    return $__ret_value_tfBenchmark;    
+    return $__ret_value_tfBenchmark;
 }
 
 # Run NAMD benchmark
@@ -177,7 +188,40 @@ function namdBenchmark {
     __cmd_array_namdBenchmark=("$__cmd_python_namdBenchmark run_benchmarks.py -b apoa1 stmv -c 16-16 -d 0"); runCmd __cmd_array_namdBenchmark "ERR"
     runCmd __cmd_array_namdBenchmark "ERR" 0 && stopLoadBar "APOA1 STMV benchmark Done" || { stopLoadBar "APOA1 STMV benchmark Failed" "ERR"; __ret_value_namdBenchmark=1; }
 
-    return $__ret_value_namdBenchmark;    
+    return $__ret_value_namdBenchmark;
+}
+
+# Run MPI benchmark
+function mpiBenchmark {
+    export OMPI_HOME=/opt/rocm/RET/ompi
+    #local __url_mpiBenchmark="https://github.com/ROCmSoftwarePlatform/hipOMB.git"
+    local __url_mpiBenchmark="https://github.com/yuq/osu-micro-benchmarks-5.3.2.git"
+    local __cmd_array_mpiBenchmark=()
+    local __cmd_mpirun_mpiBenchmark="${OMPI_HOME}/bin/mpirun"
+    local __cmd_ret_mpiBenchmark
+    local __ret_value_mpiBenchmark=0
+
+    if [ ! -d "/opt/rocm/RET/omb" ]; then
+        startLoadBar "Setting up OSU MPI Benchmark"; printf '\n'
+        __cmd_array_mpiBenchmark=("cd /opt/rocm/RET && git clone $__url_mpiBenchmark omb")
+	runCmd __cmd_array_mpiBenchmark "WARN"
+	__cmd_array_mpiBenchmark=("cd /opt/rocm/RET/omb && autoreconf -ivf && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=/opt/rocm/RET/omb CC=$OMPI_HOME/bin/mpic++ CXX=$OMPI_HOME/bin/mpicxx LDFLAGS='-L$OMPI_HOME/lib -lmpi -L/opt/rocm/lib -lhip_hcc' CPPFLAGS='-std=c++11' && make -j install")
+        runCmd __cmd_array_mpiBenchmark "ERR"
+        stopLoadBar
+    fi
+
+    # Run the benchmark
+    startLoadBar "Run OSU MPI Benchmark"; printf '\n'
+
+    __cmd_array_mpiBenchmark=("source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr /opt/rocm/RET/omb/mpi/pt2pt/osu_bw -d rocm D D 0 1 ")
+    runCmd __cmd_array_mpiBenchmark "ERR"
+    #__cmd_array_mpiBenchmark=("source /etc/profile.d/mpi.sh && $__cmd_mpirun_mpiBenchmark -np 2 --mca osc ucx --mca spml ucx -x LD_LIBRARY_PATH --allow-run-as-root -mca pml ucx -x UCX_TLS=sm,self,rocm_copy,rocm_ipc,rocm_gdr /opt/rocm/RET/omb/mpi/pt2pt/osu_lat -d rocm D D 0 1 ")
+    #runCmd __cmd_array_mpiBenchmark "ERR"
+
+    __cmd_ret_mpiBenchmark="$?"
+    [ "$__cmd_ret_mpiBenchmark" -eq 0 ] && stopLoadBar "OSU MPI benchmark Done" || { stopLoadBar "OSU MPI benchmark Failed" "ERR"; __ret_value_mpiBenchmark=1; }
+
+    return $__ret_value_mpiBenchmark
 }
 
 # Build Package Array by key and check if packages already installed
@@ -426,6 +470,72 @@ function installNAMD {
                                        || stopLoadBar "Install Completed Successfully."
 }
 
+# Install MPI (Open MPI, UCX, GDRcopy) from source
+# This should be removed once ROCm-enable DEP & RPM packages are available in the future
+function installMPI {
+    local __url_OpenMPI_installMPI="https://github.com/open-mpi/ompi.git -b v4.0.x"
+    local __url_GDRCOPY_installMPI="https://github.com/NVIDIA/gdrcopy.git -b v1.3"
+    local __url_UCX_installMPI="https://github.com/openucx/ucx.git -b v1.6.x"
+
+    local __inst_root_installMPI="/opt/rocm/RET"
+    local __inst_root_installOpenMPI="$__inst_root_installMPI/ompi"
+    local __inst_root_installGDRCOPY="$__inst_root_installMPI/gdrcopy"
+    local __inst_root_installGDRCOPY_LIB="$__inst_root_installGDRCOPY/lib64"
+    local __inst_root_installGDRCOPY_INCLUDE="$__inst_root_installGDRCOPY/include"
+    local __inst_root_installUCX="$__inst_root_installMPI/ucx"
+
+    # Build GDRCPY ##############################################################################################
+    startLoadBar "Build GDRcopy"
+
+    if [ -d $__inst_root_installGDRCOPY ]; then
+        __cmd_array_installMPI=("rm -fr $__inst_root_installGDRCOPY")
+        runCmd __cmd_array_installMPI "ERR"
+    fi
+    __cmd_array_installMPI=("git clone ${__url_GDRCOPY_installMPI} $__inst_root_installGDRCOPY")
+    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("cd $__inst_root_installGDRCOPY && mkdir -p $__inst_root_installGDRCOPY_LIB $__inst_root_installGDRCOPY_INCLUDE")
+    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("make PREFIX=$__inst_root_installGDRCOPY lib install && cd $__inst_root_installMPI")
+    runCmd __cmd_array_installMPI "ERR"
+
+    stopLoadBar "Build GDRcopy completed successfully."
+
+    # Build UCX ##############################################################################################
+    startLoadBar "Build UCX"
+
+    if [ -d $__inst_root_installUCX ]; then
+        __cmd_array_installMPI=("rm -fr $__inst_root_installUCX")
+        runCmd __cmd_array_installMPI "ERR"
+    fi
+    __cmd_array_installMPI=("git clone ${__url_UCX_installMPI} $__inst_root_installUCX")
+    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("cd $__inst_root_installUCX && ./autogen.sh && mkdir build && cd build && ../contrib/configure-release --prefix=$__inst_root_installUCX --with-rocm=/opt/rocm --with-gdrcopy=$__inst_root_installGDRCOPY --enable-gtest --enable-examples && sudo make -j install && cd $__inst_root_installMPI")
+    #buildFromSource "$__url_UCX_installMPI" "$__inst_root_installUCX" __cmd_array_installMPI "ucx" "ucx" "0"
+    runCmd __cmd_array_installMPI "ERR"
+
+    stopLoadBar "Build UCX completed successfully."
+
+    # Build OMPI ##############################################################################################
+    startLoadBar "Build Open MPI"
+
+    if [ -d $__inst_root_installOpenMPI ]; then
+        __cmd_array_installMPI=("rm -fr $__inst_root_installOpenMPI")
+        runCmd __cmd_array_installMPI "ERR"
+    fi
+    __cmd_array_installMPI=("git clone ${__url_OpenMPI_installMPI} $__inst_root_installOpenMPI")
+    runCmd __cmd_array_installMPI "ERR"
+    __cmd_array_installMPI=("cd $__inst_root_installOpenMPI && ./autogen.pl && mkdir build && cd build && ../configure --prefix=$__inst_root_installOpenMPI --with-ucx=$__inst_root_installUCX --enable-mca-no-build=btl-uct && sudo make -j install && cd $__inst_root_installMPI")
+    #buildFromSource "$__url_OpenMPI_installMPI" "$__inst_root_installOpenMPI" __cmd_array_installMPI "ompi" "ompi" "0"
+    runCmd __cmd_array_installMPI "ERR"
+
+    stopLoadBar "Build Open MPI completed successfully."
+
+    # Back to the RET folder
+    cd "$__retPath_installMPI"
+
+    [ $? -ne 0 ] && stopLoadBar "There was a problem building MPI!" "ERR" "make" \
+                                       || stopLoadBar "Install Completed Successfully."
+}
 
 # Build Package with cmake
 # Input $1: source code url


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The Open MPI in OS distro does not support GPU for P2P communication, which requires ROCm-enabled UCX that needs to be build separately.

**Describe the solution you'd like**
To build Open MPI support with UCX for ROCm described here: https://github.com/openucx/ucx/wiki/Build-and-run-ROCM-UCX-OpenMPI. Also include OSU Micro Benchmark for sanity testing.

**Describe alternatives you've considered**
ROCm software repository will ultimately provide this ROCm-enabled MPI support in the future, to provide binary distribution of Open MPI and UCX for each distribution, because building it each time can take half hour.

**Additional context**
[ret.log](https://github.com/rocmsys/RET/files/3998707/ret.log)