### PR TITLE
Fixes for RET Tool issues with latest ROCm

### DIFF
--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -21,10 +21,10 @@ os_support:
       - 18.04
     kernel:
       - 16.04:
-        - version: 4.13|4.15|4.17
+        - version: 4.13|4.15|4.17|5.3
         - default: 4.15
       - 18.04:
-        - version: 4.15|4.18|5.0
+        - version: 4.15|4.18|5.0|5.3
         - default: 5.0
 
   - os: RedHat

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -113,9 +113,9 @@ dependencies:
     - CentOS:
       - name: epel-release
         version: latest
-      - name: kernel-headers-`uname -r`
+      - name: kernel-headers-`yum info kernel -q | grep Version | sed "s/[^0-9^.]//g" | head -1`
         version: latest
-      - name: kernel-devel-`uname -r`
+      - name: kernel-devel-`yum info kernel -q | grep Version | sed "s/[^0-9^.]//g" | head -1`
         version: latest 
       - name: dkms
         version: latest

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -107,6 +107,8 @@ dependencies:
         version: latest
       - name: python3-pip
         version: latest
+      - name: lshw
+        version: latest
     # CentOS Global Dependencies    
     - CentOS:
       - name: epel-release

--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -43,8 +43,12 @@ os_support:
     release:
       - 7.5
       - 7.6
+      - 7.8
     kernel:
       - 7.6:
+        - version: 3.10
+        - default: 3.10
+      - 7.8:
         - version: 3.10
         - default: 3.10
 

--- a/requirements/rocm.yml
+++ b/requirements/rocm.yml
@@ -18,10 +18,10 @@
   version: latest
 - name: rocm-utils
   version: latest
-- name: rocm-profiler
-  version: latest
-- name: cxlactivitylogger
-  version: latest
+  #- name: rocm-profiler
+  #  version: latest
+  #- name: cxlactivitylogger
+  #  version: latest
 - name: miopen-hip
   version: latest
 - name: miopengemm

--- a/requirements/rocm.yml
+++ b/requirements/rocm.yml
@@ -10,7 +10,7 @@
   version: latest
 - name: hsa-ext-rocr-dev
   version: latest
-- name: hsakmt-roct-dev
+- name: hsakmt-roct-dev$__arch_flag
   version: latest
 - name: hsa-rocr-dev
   version: latest

--- a/src/functions
+++ b/src/functions
@@ -407,6 +407,7 @@ function getOSInfo {
     if [ -f /etc/centos-release ]; then #Use this to get the right COS version X.X
         __OS="CentOS"
         __VER=$(cat /etc/centos-release | sed 's|^.*[^0-9]\('$__digit'\.'$__digit'\)\(\.[0-9]*\).*$|\1|g')
+	__KERNEL=$(yum info kernel -q | grep Version | sed "s/[^0-9^.]//g" | head -1)
     elif [ -f /etc/os-release ]; then
         . /etc/os-release
         case $ID in

--- a/src/functions
+++ b/src/functions
@@ -408,6 +408,7 @@ function getOSInfo {
         __OS="CentOS"
         __VER=$(cat /etc/centos-release | sed 's|^.*[^0-9]\('$__digit'\.'$__digit'\)\(\.[0-9]*\).*$|\1|g')
 	__KERNEL=$(yum info kernel -q | grep Version | sed "s/[^0-9^.]//g" | head -1)
+	__arch_flag="el.x86_64"
     elif [ -f /etc/os-release ]; then
         . /etc/os-release
         case $ID in


### PR DESCRIPTION
1. Allowed support  for Ubuntu 16.x/18.x 3.5 kernel versions.
2. Added lshw tool to Ubuntu global dependency list.
3. On docker containers "uname -r" shows the kernel version of host machine. So changed the command to get the kernel version on CentOS.
4. Removed the packages which are already installed by rocm-dkms or not available.