### PR TITLE
fix lynx & python3 installation for CentOS-8.x

### DIFF
--- a/requirements/req.yml
+++ b/requirements/req.yml
@@ -128,7 +128,7 @@ dependencies:
         version: latest
       - name: python2-pip
         version: latest
-      - name: python36-pip
+      - name: python3-pip
         version: latest
       - name: lshw
         version: latest

--- a/src/functions
+++ b/src/functions
@@ -409,6 +409,11 @@ function getOSInfo {
         __VER=$(cat /etc/centos-release | sed 's|^.*[^0-9]\('$__digit'\.'$__digit'\)\(\.[0-9]*\).*$|\1|g')
 	__KERNEL=$(yum info kernel -q | grep Version | sed "s/[^0-9^.]//g" | head -1)
 	__arch_flag="el.x86_64"
+	VER1=7.8
+	if (( ${__VER%%.*} > ${VER1%%.*} )) ; then
+	$(yum install -y dnf-plugins-core -y)
+	$(yum config-manager --set-enabled PowerTools)
+	fi
     elif [ -f /etc/os-release ]; then
         . /etc/os-release
         case $ID in


### PR DESCRIPTION
lynx : The lynx command was moved over to the PowerTools repository.
python : replaced python36 with python3. 